### PR TITLE
Example for `compute_spect_slope`

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -53,7 +53,7 @@ Functions
    compute_katz_fd
    compute_zero_crossings
    compute_line_length
-   compute_powercurve_deviation
+   compute_spect_slope
    compute_spect_entropy
    compute_svd_entropy
    compute_svd_fisher_info

--- a/examples/plot_psd_slope_estimation.py
+++ b/examples/plot_psd_slope_estimation.py
@@ -82,8 +82,8 @@ psd, freqs = _psd[0, mask], _freqs[mask]
 # by ``compute_spect_slope`` because, in the feature function, the linear
 # regression fit is done in the log10-log10 scale.
 res = compute_spect_slope(sfreq, data, fmin=0.1, fmax=40)
-slope = -res[0]
-intercept = 10 ** res[1]
+slope = -res[1]
+intercept = 10 ** res[0]
 print('The estimated slope (respectively intercept) is: %1.2f (resp. %1.3e)' %
       (slope, intercept))
 

--- a/examples/plot_psd_slope_estimation.py
+++ b/examples/plot_psd_slope_estimation.py
@@ -1,0 +1,103 @@
+"""
+===================================================================
+Estimation of the slope and intercept of the Power Spectral Density
+===================================================================
+
+This example aims at showing how the utility function `power_spectrum` and 
+the feature function :func:`mne_features.univariate.compute_spect_slope` can 
+be used to estimate the slope and the intercept of the Power Spectral 
+Density (PSD, computed using the FFT of the signal).
+
+The code for this example is based on the method proposed in:
+
+Jean-Baptiste SCHIRATTI, Jean-Eudes LE DOUGET, Michel LE VAN QUYEN,
+Slim ESSID, Alexandre GRAMFORT,
+"An ensemble learning approach to detect epileptic seizures from long
+intracranial EEG recordings"
+Proc. IEEE ICASSP Conf. 2018
+
+.. note::
+
+    This example is for illustration purposes, as other methods
+    may lead to more robust/reliable estimation of the slope and intercept 
+    of the PSD.
+
+"""  # noqa
+
+# Author: Jean-Baptiste Schiratti <jean.baptiste.schiratti@gmail.com>
+#         Alexandre Gramfort <alexandre.gramfort@inria.fr>
+# License: BSD 3 clause
+
+import matplotlib.pyplot as plt
+import mne
+import numpy as np
+from mne.datasets import sample
+
+from mne_features.univariate import compute_spect_slope
+from mne_features.utils import power_spectrum
+
+print(__doc__)
+
+###############################################################################
+# Let us import the data using MNE-Python and epoch it:
+
+data_path = sample.data_path()
+raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
+event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
+tmin, tmax = -0.2, 0.5
+event_id = dict(aud_l=1, vis_l=3)
+
+# Setup for reading the raw data
+raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw.filter(.5, None, fir_design='firwin')
+events = mne.read_events(event_fname)
+picks = mne.pick_types(raw.info, meg=False, eeg=True)
+
+# Read epochs
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks, proj=True,
+                    baseline=None, preload=True)
+
+###############################################################################
+# Estimate the slope (and the intercept) of the PSD. For the sake of the
+# example, a single epoch and channel are used to estimate the slope and the
+# intercept.
+
+data = epochs.get_data()[0, 1, :].reshape((1, -1))
+sfreq = epochs.info['sfreq']
+
+# Compute the (one-sided) PSD using FFT. The ``mask`` variable allows to
+# select only the part of the PSD which corresponds to frequencies between
+# 0.1Hz and 40Hz (the data used in this example is already low-pass filtered
+# at 40Hz).
+_psd, _freqs = power_spectrum(sfreq, data)
+mask = np.logical_and(0.1 <= _freqs, _freqs <= 40)
+
+psd, freqs = _psd[0, mask], _freqs[mask]
+
+# Estimate the slope (and the intercept) of the PSD. The function
+# :func:`compute_spect_slope` assumes that the PSD of the signal is of the
+# form: ``psd[f] = b / (f ** a)``. The coefficients a and b are respectively
+# called *slope* and *intercept* of the Power Spectral Density. The values of
+# the variables ``slope`` and ``intercept`` differ from the values returned
+# by ``compute_spect_slope`` because, in the feature function, the linear
+# regression fit is done in the log10-log10 scale.
+res = compute_spect_slope(sfreq, data, fmin=0.1, fmax=40)
+slope = -res[0]
+intercept = 10 ** res[1]
+print('The estimated slope (respectively intercept) is: %1.2f (resp. %1.3e)' %
+      (slope, intercept))
+
+# Plot the PSD together with the ``b / (f ** a)`` curve (estimated decay of
+# the PSD with frequency) and the ``b / f`` curve (classical decay of the PSD
+# with frequency).
+plt.figure()
+plt.plot(freqs, psd, '-b', lw=2, label='PSD')
+plt.plot(freqs, intercept / (freqs ** slope), '-r', lw=2,
+         label='b / (f ** a)')
+plt.plot(freqs, intercept / (freqs ** 1.), '-m', lw=1, label='b / f')
+plt.xlabel('f (frequency, in Hz)')
+plt.ylabel('PSD (in Volts ** 2 / Hz)')
+plt.ylim([np.min(psd), np.max(psd)])
+plt.xlim([1, 40])
+plt.legend(loc='upper right')
+plt.show()

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -30,7 +30,7 @@ from mne_features.univariate import (_slope_lstsq, _accumulate_std,
                                      compute_spect_edge_freq,
                                      compute_wavelet_coef_energy,
                                      compute_teager_kaiser_energy,
-                                     compute_powercurve_deviation)
+                                     compute_spect_slope)
 
 rng = np.random.RandomState(42)
 sfreq = 512.
@@ -255,7 +255,7 @@ def test_energy_freq_bands():
     assert_equal(band_energy > 0.98 * tot_energy, True)
 
 
-def test_powercurve_deviation():
+def test_spect_slope():
     """Test for :func:`compute_powercurve_deviation`.
 
     We impose the power to be written as power(f) = k1/f**theta with noise
@@ -295,8 +295,8 @@ def test_powercurve_deviation():
 
     # We test our estimates
     intercept, slope, mse, r2 = \
-        compute_powercurve_deviation(sfreq=sfreq, data=sig.reshape(1, -1),
-                                     with_intercept=True)
+        compute_spect_slope(sfreq=sfreq, data=sig.reshape(1, -1),
+                            with_intercept=True)
 
     # obtained by the expression ps[f] = 2 * [ (spect[f]^2) / (n_times^2) ]
     # and plug-in: power(f) = k1/f**theta with noise
@@ -304,11 +304,8 @@ def test_powercurve_deviation():
     theta_estimate = - slope
 
     np.testing.assert_almost_equal(k1, k1_estimate, decimal=1)
-
     np.testing.assert_almost_equal(theta, theta_estimate, decimal=1)
-
     assert r2 > 0.95, "Explained variance is not high enough."
-
     assert mse < 0.5, "Residual has too large standard deviation."
 
 
@@ -378,6 +375,7 @@ if __name__ == '__main__':
     test_higuchi_fd()
     test_katz_fd()
     test_energy_freq_bands()
+    test_spect_slope()
     test_spect_entropy()
     test_spect_edge_freq()
     test_svd_entropy()

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -1016,8 +1016,8 @@ def compute_svd_entropy(data, tau=2, emb=10):
     return -np.sum(np.multiply(sv_norm, np.log2(sv_norm)), axis=-1)
 
 
-def compute_powercurve_deviation(sfreq, data, fmin=0.1, fmax=50,
-                                 with_intercept=True):
+def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
+                        with_intercept=True):
     """Linear regression of the the log-log frequency-curve (per channel).
 
     Using a linear regression, the function estimates the slope and the
@@ -1051,7 +1051,7 @@ def compute_powercurve_deviation(sfreq, data, fmin=0.1, fmax=50,
 
     Notes
     -----
-    Alias of the feature function: **powercurve_deviation**. See [1]_
+    Alias of the feature function: **spect_slope**. See [1]_
     and [2]_.
 
     References
@@ -1076,22 +1076,16 @@ def compute_powercurve_deviation(sfreq, data, fmin=0.1, fmax=50,
     # linear fit
     lm = LinearRegression()
     fit_info = np.empty((n_channels, 4))
-
     for idx, power in enumerate(psd):
-
         lm.fit(freqs.reshape(-1, 1), power)
-        coef = float(lm.coef_)
-        intercept = float(lm.intercept_)
+        fit_info[idx, 0] = lm.coef_
+        fit_info[idx, 1] = lm.intercept_
         power_estimate = lm.predict(freqs.reshape(-1, 1))
-        mse = float(mean_squared_error(power, power_estimate))
-        r2 = float(explained_variance_score(power, power_estimate))
-        fit_info[idx, :] = np.array([intercept, coef, mse, r2])
-
+        fit_info[idx, 2] = mean_squared_error(power, power_estimate)
+        fit_info[idx, 3] = explained_variance_score(power, power_estimate)
     if not with_intercept:
-
         fit_info = fit_info[:, 1:]
-
-    return(fit_info.ravel())
+    return fit_info.ravel()
 
 
 def compute_svd_fisher_info(data, tau=2, emb=10):

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -1078,8 +1078,8 @@ def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
     fit_info = np.empty((n_channels, 4))
     for idx, power in enumerate(psd):
         lm.fit(freqs.reshape(-1, 1), power)
-        fit_info[idx, 0] = lm.coef_
-        fit_info[idx, 1] = lm.intercept_
+        fit_info[idx, 0] = lm.intercept_
+        fit_info[idx, 1] = lm.coef_
         power_estimate = lm.predict(freqs.reshape(-1, 1))
         fit_info[idx, 2] = mean_squared_error(power, power_estimate)
         fit_info[idx, 3] = explained_variance_score(power, power_estimate)


### PR DESCRIPTION
I added an example for `compute_spect_slope` (previously called `compute_powercurve_deviation`). The PR also contains minor changes to the code.